### PR TITLE
Marvell/Armada: RealTimeClockLib: Update bus parameters

### DIFF
--- a/Platforms/Marvell/Armada/Library/RealTimeClockLib/RealTimeClockLib.c
+++ b/Platforms/Marvell/Armada/Library/RealTimeClockLib/RealTimeClockLib.c
@@ -250,6 +250,11 @@ LibRtcInitialize (
 
   /* Update RTC-MBUS bridge timing parameters */
   MmioAndThenOr32 (
+          mArmadaRtcBase + RTC_BRIDGE_TIMING_CTRL0_REG_OFFS,
+          ~(RTC_WRITE_SETUP_DELAY_MASK | RTC_WRITE_PERIOD_DELAY_MASK),
+          (RTC_WRITE_SETUP_DELAY_DEFAULT | RTC_WRITE_PERIOD_DELAY_DEFAULT)
+          );
+  MmioAndThenOr32 (
           mArmadaRtcBase + RTC_BRIDGE_TIMING_CTRL1_REG_OFFS,
           ~RTC_READ_OUTPUT_DELAY_MASK,
           RTC_READ_OUTPUT_DELAY_DEFAULT

--- a/Platforms/Marvell/Armada/Library/RealTimeClockLib/RealTimeClockLib.h
+++ b/Platforms/Marvell/Armada/Library/RealTimeClockLib/RealTimeClockLib.h
@@ -41,10 +41,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define RTC_IRQ_2_CONFIG_REG                    0x8
 #define RTC_IRQ_ALARM_EN                        0x1
 #define RTC_ALARM_2_REG                         0x14
+#define RTC_BRIDGE_TIMING_CTRL0_REG_OFFS        0x80
 #define RTC_BRIDGE_TIMING_CTRL1_REG_OFFS        0x84
 #define RTC_IRQ_STATUS_REG                      0x90
 #define RTC_IRQ_ALARM_MASK                      0x1
+#define RTC_WRITE_PERIOD_DELAY_MASK             0xFFFF
+#define RTC_WRITE_PERIOD_DELAY_DEFAULT          0x3FF
+#define RTC_WRITE_SETUP_DELAY_MASK              (0xFFFF << 16)
+#define RTC_WRITE_SETUP_DELAY_DEFAULT           (0x29 << 16)
 #define RTC_READ_OUTPUT_DELAY_MASK              0xFFFF
-#define RTC_READ_OUTPUT_DELAY_DEFAULT           0x1F
+#define RTC_READ_OUTPUT_DELAY_DEFAULT           0x3F
 
 #endif /* __RTCLIB_H__ */


### PR DESCRIPTION
Adjust bus timing parameters to make reading and updating the RTC
reliable.

This patch aligns the bus configuration to the one used by Linux.

Contributed-under: TianoCore Contribution Agreement 1.1
Signed-off-by: Mark Kettenis <kettenis@openbsd.org>